### PR TITLE
Add Versa Analytics version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ url
 
 # Usage
 ```
-nmap --script infiltrator --script-args infiltrator.version=true -sS -sU -p U:161,T:80,443,8008 <target> or -iL <targets.txt>
+nmap --script infiltrator --script-args infiltrator.version=true -sS -sU -p U:161,T:80,443,8008,8080,8443 <target> or -iL <targets.txt>
 ```
 # Example
 ![Output example](output.png)


### PR DESCRIPTION
Example results:
```
Nmap scan report for ...
Host is up (0.17s latency).

PORT     STATE         SERVICE
80/tcp   filtered      http
443/tcp  closed        https
8008/tcp filtered      http
8080/tcp open          http-proxy
| infiltrator:
|   status: success
|   method: http-server
|   product: Versa Analytics
|   host_addr: ...
|   host_port: 8080
|_  version: 16.1r2s6
```